### PR TITLE
Fix for Gatsby build complaint: no image.base

### DIFF
--- a/src/templates/blog-post/index.js
+++ b/src/templates/blog-post/index.js
@@ -36,9 +36,7 @@ export const pageQuery = graphql`
                 date(formatString: "MMMM DD, YYYY")
                 description
                 download
-                image {
-                    base
-                }
+                image
                 link {
                     title
                     url


### PR DESCRIPTION
It was complaining during builds 🤷

I'm going to move to some other site generator soon/eventually... 