### PR TITLE
Maybe image has base after all...

### DIFF
--- a/src/templates/blog-post/index.js
+++ b/src/templates/blog-post/index.js
@@ -36,7 +36,9 @@ export const pageQuery = graphql`
                 date(formatString: "MMMM DD, YYYY")
                 description
                 download
-                image
+                image {
+                    base
+                }
                 link {
                     title
                     url


### PR DESCRIPTION
🙃 on Vercel:

```plaintext
error There was an error in your GraphQL query:
11:22:18.931 |  
11:22:18.931 | Field "image" of type "File" must have a selection of subfields. Did you mean "image { ... }"?
11:22:18.968 |  
11:22:18.968 |  
11:22:18.968 | GraphQLError: Field "image" of type "File" must have a selection of subfields.   Did you mean "image { ... }"?
11:22:18.968 |  
11:22:18.968 | - query-compiler.js:209 extractOperations
11:22:18.968 | [path0]/[gatsby]/src/query/query-compiler.js:209:20
11:22:18.968
```